### PR TITLE
OSX: find package qt5printsupport work around

### DIFF
--- a/cmake/Qt5Widgets_HunterPlugin_5_5.cmake
+++ b/cmake/Qt5Widgets_HunterPlugin_5_5.cmake
@@ -81,9 +81,19 @@ elseif(APPLE)
       "static_qt_plugins.cpp"
   )
 
-  # Lead to configuration errors (cyclic dependencies)
-  # find_package(Qt5PrintSupport REQUIRED)
-  # _qt_cmake_extra_helpers_add_interface(Qt5::Widgets Qt5::PrintSupport)
+# Cyclic dependency when using find_package(Qt5PrintSupport) as it tries to find
+# Qt5Widgets. As a work-around, we check for the a variable set in
+# FindQt5PrintSupport.cmake.  This is fragile, but allows the client code to
+# link without changes
+  string(COMPARE EQUAL
+      "${Qt5PrintSupport_VERSION_STRING}"
+      ""
+      _find_package_print_support_not_ran
+  )
+  if(_find_package_print_support_not_ran)
+    find_package(Qt5PrintSupport REQUIRED)
+  endif()
+  _qt_cmake_extra_helpers_add_interface(Qt5::Widgets Qt5::PrintSupport)
 
   # Frameworks
   _qt_cmake_extra_helpers_add_interface(Qt5::Widgets "-framework Carbon")


### PR DESCRIPTION
Hi Ruslan, can you check if this is acceptable?

Without having PrintSupport as a dependency of Widgets, I can't even link `examples/qt-widgets`, as it fails with:

```
Undefined symbols for architecture x86_64:
  "QPlatformPrintDevice::createPageSize(QString const&, QSize const&, QString const&)", referenced from:
      QCocoaPrintDevice::createPageSize(OpaquePMPaper* const&) const in libqcocoa.a(qcocoaprintdevice.o)
  "QPlatformPrintDevice::QPlatformPrintDevice(QString const&)", referenced from:
      QCocoaPrintDevice::QCocoaPrintDevice(QString const&) in libqcocoa.a(qcocoaprintdevice.o)
(...) all related to QPlatformPrintDevice
```
