### PR TITLE
Fix Windows 7 compatibility

### DIFF
--- a/cmake/Qt5Core_HunterPlugin.cmake
+++ b/cmake/Qt5Core_HunterPlugin.cmake
@@ -77,8 +77,13 @@ elseif(MSVC)
   _qt_cmake_extra_helpers_add_interface(Qt5::Core ws2_32)
 
   # defined: '_GetFileVersionInfoSizeW'
-  _qt_cmake_extra_helpers_add_interface(Qt5::Core Mincore)
   _qt_cmake_extra_helpers_add_interface(Qt5::Core Version)
+
+  # defined: 'NetShareEnum'
+  _qt_cmake_extra_helpers_add_interface(Qt5::Core Netapi32)
+
+  # defined: '__imp__GetUserProfileDirectoryW'
+  _qt_cmake_extra_helpers_add_interface(Qt5::Core Userenv)
 
   # defined: '__imp__timeSetEvent'
   _qt_cmake_extra_helpers_add_interface(Qt5::Core Winmm)


### PR DESCRIPTION
Linking to Mincore library breaks the compatibility with Windows 7.
Instead, link to the individual system libraries.

Reference: https://docs.microsoft.com/en-us/windows/desktop/apiindex/windows-8-api-sets

Signed-off-by: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>